### PR TITLE
repl: reset tty cooked mode on ^D

### DIFF
--- a/src/repl.js
+++ b/src/repl.js
@@ -411,7 +411,7 @@ import * as uv from "uv";
     function control_d() {
         if (cmd.length == 0) {
             stdout.write("\n");
-            return -3; /* exit read eval print loop */
+            exit(0);
         } else {
             delete_char_dir(1);
         }
@@ -810,11 +810,6 @@ import * as uv from "uv";
                 return;
             case -2:
                 readline_cb(null);
-                return;
-            case -3:
-                /* uninstall a Ctrl-C signal handler */
-                sigint_h.close();
-                sigint_h = undefined;
                 return;
             }
             last_fun = this_fun;


### PR DESCRIPTION
Before this commit, pressing ^D twice would exit the REPL but leave
the terminal in raw mode. Fix that by calling exit() directly instead
of closing the SIGINT listener.

That leaves just one reference to the `sigint_h` variable in repl.js,
the assignment in termInit(), but stepping through the code suggests
that's okay: the garbage collector marks it but doesn't collect it.

Fixes: https://github.com/saghul/quv/issues/18