### PR TITLE
timers: properly fix timer finalization

### DIFF
--- a/src/quv/timers.c
+++ b/src/quv/timers.c
@@ -47,6 +47,10 @@ static void clear_timer(QUVTimer *th) {
         th->argv[i] = JS_UNDEFINED;
     }
     th->argc = 0;
+
+    JSValue obj = th->obj;
+    th->obj = JS_UNDEFINED;
+    JS_FreeValue(ctx, obj);
 }
 
 static void call_timer(QUVTimer *th) {
@@ -64,7 +68,6 @@ static void call_timer(QUVTimer *th) {
 static void uv__timer_close(uv_handle_t *handle) {
     QUVTimer *th = handle->data;
     CHECK_NOT_NULL(th);
-    JS_FreeValue(th->ctx, th->obj);
     free(th);
 }
 


### PR DESCRIPTION
We must get rid of all the JS objects in the finalizer, that's rule
number 1.

Now in this case, when clear_timer is called we may drop the single
reference that holds the timer JS object (th->obj) and the finalizer
will run on the spot, de-refing it again, causing an assertion. Avoid it
by using a local variable and reseting its value before freeing it.