### PR TITLE
misc: fix leaks when using JS_ToCStringLen

### DIFF
--- a/API.md
+++ b/API.md
@@ -48,9 +48,9 @@ All synchronous APIs return a Promise, there are no callbacks.
 - `getpeername()`
 - `getsockname()`
 - `listen([backlog])`
-- `read()`
+- `read(buffer, [offset, [length]])`
 - `shutdown()`
-- `write(data)`
+- `write(buffer, [offset, [length]])`
 
 ### UDP([family])
 
@@ -73,18 +73,18 @@ All synchronous APIs return a Promise, there are no callbacks.
 - `getpeername()`
 - `getsockname()`
 - `listen([backlog])`
-- `read()`
+- `read(buffer, [offset, [length]])`
 - `shutdown()`
-- `write(data)`
+- `write(buffer, [offset, [length]])`
 
 ### TTY(fd, readable)
 
 - `close()`
 - `fileno()`
 - `getWinSize()`
-- `read()`
+- `read(buffer, [offset, [length]])`
 - `setMode(mode)`
-- `write(data)`
+- `write(buffer, [offset, [length]])`
 
 ### Constants
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -292,14 +292,8 @@ static JSValue quv_file_rw(JSContext *ctx, JSValueConst this_val, int argc, JSVa
         return JS_EXCEPTION;
 
     /* arg 0: buffer */
-    JSValue jsData = argv[0];
     size_t size;
-    char *buf;
-    if (magic && JS_IsString(jsData))
-        buf = (char *) JS_ToCStringLen(ctx, &size, jsData);
-    else
-        buf = (char *) JS_GetArrayBuffer(ctx, &size, jsData);
-
+    char *buf = (char *) JS_GetArrayBuffer(ctx, &size, argv[0]);
     if (!buf)
         return JS_EXCEPTION;
 
@@ -493,11 +487,13 @@ static JSValue quv_fs_open(JSContext *ctx, JSValueConst this_val, int argc, JSVa
     path = JS_ToCString(ctx, argv[0]);
     if (!path)
         return JS_EXCEPTION;
+
     strflags = JS_ToCStringLen(ctx, &len, argv[1]);
     if (!strflags)
         return JS_EXCEPTION;
-
     flags = js__uv_open_flags(strflags, len);
+    JS_FreeCString(ctx, strflags);
+
     if (JS_ToInt32(ctx, &mode, argv[2]))
         return JS_EXCEPTION;
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -190,18 +190,9 @@ static JSValue quv_stream_write(JSContext *ctx, QUVStream *s, int argc, JSValueC
     if (!s)
         return JS_EXCEPTION;
 
-    JSValue jsData = argv[0];
-
-    size_t size;
-    char *buf;
-
     /* arg 0: buffer */
-    if (JS_IsString(jsData)) {
-        buf = (char *) JS_ToCStringLen(ctx, &size, jsData);
-    } else {
-        buf = (char *) JS_GetArrayBuffer(ctx, &size, jsData);
-    }
-
+    size_t size;
+    char *buf = (char *) JS_GetArrayBuffer(ctx, &size, argv[0]);
     if (!buf)
         return JS_EXCEPTION;
 
@@ -239,12 +230,12 @@ static JSValue quv_stream_write(JSContext *ctx, QUVStream *s, int argc, JSValueC
         return JS_EXCEPTION;
 
     wr->req.data = wr;
-    wr->data = JS_DupValue(ctx, jsData);
+    wr->data = JS_DupValue(ctx, argv[0]);
 
     b = uv_buf_init(buf, len);
     r = uv_write(&wr->req, &s->h.stream, &b, 1, uv__stream_write_cb);
     if (r != 0) {
-        JS_FreeValue(ctx, jsData);
+        JS_FreeValue(ctx, argv[0]);
         js_free(ctx, wr);
         return quv_throw_errno(ctx, r);
     }

--- a/src/udp.c
+++ b/src/udp.c
@@ -206,18 +206,9 @@ static JSValue quv_udp_send(JSContext *ctx, JSValueConst this_val, int argc, JSV
     if (!u)
         return JS_EXCEPTION;
 
-    JSValue jsData = argv[0];
-
-    size_t size;
-    char *buf;
-
     /* arg 0: buffer */
-    if (JS_IsString(jsData)) {
-        buf = (char *) JS_ToCStringLen(ctx, &size, jsData);
-    } else {
-        buf = (char *) JS_GetArrayBuffer(ctx, &size, jsData);
-    }
-
+    size_t size;
+    char *buf = (char *) JS_GetArrayBuffer(ctx, &size, argv[0]);
     if (!buf)
         return JS_EXCEPTION;
 
@@ -265,13 +256,13 @@ static JSValue quv_udp_send(JSContext *ctx, JSValueConst this_val, int argc, JSV
         return JS_EXCEPTION;
 
     sr->req.data = sr;
-    sr->data = JS_DupValue(ctx, jsData);
+    sr->data = JS_DupValue(ctx, argv[0]);
 
     b = uv_buf_init(buf, len);
 
     r = uv_udp_send(&sr->req, &u->udp, &b, 1, sa, uv__udp_send_cb);
     if (r != 0) {
-        JS_FreeValue(ctx, jsData);
+        JS_FreeValue(ctx, argv[0]);
         js_free(ctx, sr);
         return quv_throw_errno(ctx, r);
     }


### PR DESCRIPTION
The returned pointer must be freed with JS_FreeCString, which makes
things complicated for us, for little gain.

As such, make the API more consistent by only allowing ArrayBuffer
objects.